### PR TITLE
fix: show help if no parameters are given

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -109,7 +109,7 @@ pub fn main() !void {
     const stderr_file = std.io.getStdErr().writer();
     var bw = std.io.bufferedWriter(stdout_file);
 
-    const action = args[1];
+    const action = if (args.len > 1) args[1] else "";
     if (std.mem.eql(u8, action, "create")) {
         try ensureDirsExist();
         const fileList = try getAllFilesInADRDir(allocator);


### PR DESCRIPTION
Ensure that we have an argument on the command line before accessing the array directly. If there is not one, default it to "" which will in turn not match any if branch and execute the else, which displays the help.