### PR TITLE
feat: add link to the adl GitHub in the readme template

### DIFF
--- a/src/templates/readme_template.md
+++ b/src/templates/readme_template.md
@@ -4,7 +4,7 @@ This directory captures architecture decision records for this project.
 An architecture decision record is a justified software design choice 
 that addresses a functional or non-functional requirement of architectural significance.
 
-This directory and README is managed by adl. Please use \`adl create\` to create a new ADR.
+This directory and README is managed by [adl](https://github.com/bradcypert/adl). Please use \`adl create\` to create a new ADR.
 If you need to regenerate this readme without creating a new ADR, please use \`adl regen\`.
 
 ## Contents 


### PR DESCRIPTION
This pull request makes the existing "adl" a link for better discoverability. I started using this lovely cli in a project that will have outside contributors who may not know what `adl` is so having a link inside the readme template is crucial.

Thank you for making this lil tool :)